### PR TITLE
Fix local variable 'add' referenced before assignment

### DIFF
--- a/default.py
+++ b/default.py
@@ -248,7 +248,7 @@ def categories():
             desc = ''
 
         color = '[COLOR royalblue]'
-        
+
         add = ''
         if field['type'] == 'free' and field['authRequired'] is False:
             add = ''

--- a/default.py
+++ b/default.py
@@ -248,7 +248,8 @@ def categories():
             desc = ''
 
         color = '[COLOR royalblue]'
-
+        
+        add = ''
         if field['type'] == 'free' and field['authRequired'] is False:
             add = ''
         elif field['type'] == 'free' and field['authRequired'] is True:


### PR DESCRIPTION
Thanks so much for making this great plugin public.

This fixes an error when the `add` variable is not defined preventing the category name to be defined.